### PR TITLE
37 default config and separate input file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 This repository provides a [Checker Bundle](checker_bundle_doc.md) designed for the [ASAM Quality Checker Framework](https://github.com/asam-ev/qc-framework).
 It tests ASAM OpenMATERIAL 3D files for conformity with the standard.
 
-Any new changes in this bundle should go in the develop branch first (merging specific feature branches into develop), and only merging to main when preparing a release (exception are allow previous alignment with the CCB).
-
 - [qc_openmaterial3d](#qc_openmaterial3d)
   - [Installation and usage](#installation-and-usage)
     - [Installation using pip](#installation-using-pip)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This repository provides a [Checker Bundle](checker_bundle_doc.md) designed for the [ASAM Quality Checker Framework](https://github.com/asam-ev/qc-framework).
 It tests ASAM OpenMATERIAL 3D files for conformity with the standard.
 
+Any new changes in this bundle should go in the develop branch first (merging specific feature branches into develop), and only merging to main when preparing a release (exception are allow previous alignment with the CCB).
+
 - [qc_openmaterial3d](#qc_openmaterial3d)
   - [Installation and usage](#installation-and-usage)
     - [Installation using pip](#installation-using-pip)

--- a/qc_openmaterial3d/main.py
+++ b/qc_openmaterial3d/main.py
@@ -6,6 +6,7 @@
 
 import argparse
 import logging
+import pathlib
 import types
 
 from qc_baselib import Configuration, Result, StatusType
@@ -24,7 +25,26 @@ def args_entrypoint() -> argparse.Namespace:
     )
 
     group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("-d", "--default_config", action="store_true")
     group.add_argument("-c", "--config_path")
+
+    parser.add_argument(
+        "-i",
+        "--input_file",
+        type=pathlib.Path,
+        help="Path to the input file.",
+    )
+    parser.add_argument(
+        "-r",
+        "--result_file",
+        type=pathlib.Path,
+        help="Path to the output result file.",
+    )
+    parser.add_argument(
+        "--output_config",
+        type=pathlib.Path,
+        help="Path to save the configuration after running the checks.",
+    )
 
     parser.add_argument("-g", "--generate_markdown", action="store_true")
 
@@ -170,9 +190,38 @@ def main():
 
     logging.info("Initializing checks")
 
-
     config = Configuration()
-    config.load_from_file(xml_file_path=args.config_path)
+
+    if args.default_config:
+        logging.info("Using default configuration")
+        config.register_checker_bundle(checker_bundle_name=constants.BUNDLE_NAME)
+    else:
+        config.load_from_file(xml_file_path=args.config_path)
+
+    if args.input_file:
+        logging.info("Setting input file: %s", args.input_file)
+        config.set_config_param("InputFile", str(args.input_file))
+
+    if args.result_file:
+        logging.info("Setting result file: %s", args.result_file)
+        config.register_checker_bundle(checker_bundle_name=constants.BUNDLE_NAME)
+        config.set_checker_bundle_param(
+            checker_bundle_name=constants.BUNDLE_NAME,
+            name="resultFile",
+            value=str(args.result_file),
+        )
+
+    if (
+        config.get_checker_bundle_param(
+            checker_bundle_name=constants.BUNDLE_NAME, param_name="resultFile"
+        )
+        is None
+    ):
+        config.set_checker_bundle_param(
+            checker_bundle_name=constants.BUNDLE_NAME,
+            name="resultFile",
+            value="xom_bundle_report.xqar",
+        )
 
     result = Result()
     result.register_checker_bundle(
@@ -193,6 +242,10 @@ def main():
         ),
         generate_summary=True,
     )
+
+    if args.output_config:
+        logging.info("Writing configuration to file: %s", args.output_config)
+        config.write_to_file(args.output_config)
 
     if args.generate_markdown:
         result.write_markdown_doc("generated_checker_bundle_doc.md")


### PR DESCRIPTION
**Description**

Implemented options for default config and input file overwrite analog to the ASAM OSI Checker bundle. This way, the checker bundle can be used standalone without the QC Framework and without writing a specific configuration file for every test.

